### PR TITLE
Add JWT authentication and protect NLQ endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -14,3 +14,7 @@ REDIS_URL=redis://redis:6379
 GEMINI_API_KEY=coloque_sua_chave_aqui
 GEMINI_MODEL=gemini-1.5-flash
 DEFAULT_COMPANY_ID=company-1
+JWT_SECRET=TroqueEstaChaveJWT!
+AUTH_USERNAME=admin
+AUTH_PASSWORD=TroqueEstaSenha!
+JWT_EXPIRES_IN=1h

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ Os serviços provisionados incluem:
 4. Opcionalmente, publique uma mensagem de exemplo com `./scripts/demo_publish.sh`.
 
 O arquivo `.env` é gerado com valores padrão seguros para desenvolvimento. Ajuste conforme necessário antes de rodar em produção.
+
+## Autenticação
+
+A API expõe autenticação via JWT. Para obter um token, faça uma requisição `POST /auth/login` com `username` e `password` definidos nas variáveis de ambiente `AUTH_USERNAME` e `AUTH_PASSWORD`. Opcionalmente informe `companyId` para vincular o token a uma empresa específica; caso contrário, será usada `DEFAULT_COMPANY_ID`.
+
+Utilize o token recebido no cabeçalho `Authorization: Bearer <token>` para acessar rotas protegidas, como `POST /nlq/query`.

--- a/api/package.json
+++ b/api/package.json
@@ -8,6 +8,7 @@
     "start": "node src/index.js"
   },
   "dependencies": {
+    "@fastify/jwt": "^7.2.4",
     "dotenv": "^16.4.5",
     "fastify": "^4.26.2",
     "mqtt": "^5.3.5",

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -26,7 +26,10 @@ const requiredVars = [
   'MQTT_TOPIC',
   'GEMINI_API_KEY',
   'GEMINI_MODEL',
-  'DEFAULT_COMPANY_ID'
+  'DEFAULT_COMPANY_ID',
+  'JWT_SECRET',
+  'AUTH_USERNAME',
+  'AUTH_PASSWORD'
 ];
 
 const config = {};
@@ -42,6 +45,7 @@ for (const key of requiredVars) {
 config.NODE_ENV = process.env.NODE_ENV || 'development';
 config.REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
 config.LOG_LEVEL = process.env.LOG_LEVEL || 'info';
+config.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1h';
 
 export default Object.freeze({
   port: Number.parseInt(config.PORT, 10) || 3000,
@@ -70,5 +74,11 @@ export default Object.freeze({
     model: config.GEMINI_MODEL
   },
   defaultCompanyId: config.DEFAULT_COMPANY_ID,
-  logLevel: config.LOG_LEVEL
+  logLevel: config.LOG_LEVEL,
+  auth: {
+    username: config.AUTH_USERNAME,
+    password: config.AUTH_PASSWORD,
+    jwtSecret: config.JWT_SECRET,
+    tokenExpiresIn: config.JWT_EXPIRES_IN
+  }
 });

--- a/api/src/routes/auth.js
+++ b/api/src/routes/auth.js
@@ -1,0 +1,74 @@
+function normalizeString(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+}
+
+export default async function registerAuthRoutes(fastify) {
+  fastify.post('/auth/login', {
+    schema: {
+      body: {
+        type: 'object',
+        required: ['username', 'password'],
+        properties: {
+          username: { type: 'string', minLength: 1 },
+          password: { type: 'string', minLength: 1 },
+          companyId: { type: 'string', minLength: 1 }
+        }
+      },
+      response: {
+        200: {
+          type: 'object',
+          required: ['token', 'tokenType', 'expiresIn', 'companyId'],
+          properties: {
+            token: { type: 'string' },
+            tokenType: { type: 'string', enum: ['Bearer'] },
+            expiresIn: { type: 'string' },
+            companyId: { type: 'string' }
+          }
+        },
+        401: {
+          type: 'object',
+          required: ['code', 'message'],
+          properties: {
+            code: { type: 'string' },
+            message: { type: 'string' }
+          }
+        }
+      }
+    },
+    handler: async (request, reply) => {
+      const { username, password, companyId } = request.body;
+
+      if (
+        username !== fastify.config.auth.username ||
+        password !== fastify.config.auth.password
+      ) {
+        fastify.log.warn({ username }, 'Tentativa de login inválida');
+        reply.code(401);
+        return {
+          code: 'INVALID_CREDENTIALS',
+          message: 'Usuário ou senha inválidos.'
+        };
+      }
+
+      const normalizedCompanyId =
+        normalizeString(companyId) || fastify.config.defaultCompanyId;
+
+      const token = await reply.jwtSign({
+        sub: username,
+        companyId: normalizedCompanyId
+      });
+
+      fastify.log.info({ username }, 'Usuário autenticado com sucesso');
+
+      return {
+        token,
+        tokenType: 'Bearer',
+        expiresIn: fastify.config.auth.tokenExpiresIn,
+        companyId: normalizedCompanyId
+      };
+    }
+  });
+}

--- a/api/src/routes/nlq.js
+++ b/api/src/routes/nlq.js
@@ -33,6 +33,7 @@ function buildAnswer(rows, companyId) {
 
 export default async function registerNlqRoutes(fastify) {
   fastify.post('/nlq/query', {
+    preHandler: fastify.authenticate,
     schema: {
       body: {
         type: 'object',
@@ -54,7 +55,11 @@ export default async function registerNlqRoutes(fastify) {
         };
       }
 
-      const targetCompanyId = normalizeText(companyId) || fastify.config.defaultCompanyId;
+      const tokenCompanyId = request.user?.companyId;
+      const targetCompanyId =
+        normalizeText(companyId) ||
+        normalizeText(tokenCompanyId) ||
+        fastify.config.defaultCompanyId;
       const start = Date.now();
 
       let cypher;

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,10 @@ REDIS_URL=redis://redis:6379
 GEMINI_API_KEY=coloque_sua_chave_aqui
 GEMINI_MODEL=gemini-1.5-flash
 DEFAULT_COMPANY_ID=company-1
+JWT_SECRET=TroqueEstaChaveJWT!
+AUTH_USERNAME=admin
+AUTH_PASSWORD=TroqueEstaSenha!
+JWT_EXPIRES_IN=1h
 EOT
 
 cat <<'EOT' > docker-compose.yml


### PR DESCRIPTION
## Summary
- add @fastify/jwt configuration and a login endpoint that issues company-aware bearer tokens
- protect the NLQ query route with JWT verification and reuse the token company when none is provided in the request
- document the authentication flow and extend the generated `.env` defaults with the new credentials and secret values

## Testing
- npm install *(fails: 403 Forbidden while fetching @fastify/jwt in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc00e71eb4832db42750ac43927826