### PR TITLE
feat: reutilizar consultas NLQ aprovadas

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -43,6 +43,13 @@ config.NODE_ENV = process.env.NODE_ENV || 'development';
 config.REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
 config.LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 
+const nlqApprovalThresholdRaw = process.env.NLQ_APPROVAL_THRESHOLD;
+let nlqApprovalThreshold = Number.parseFloat(nlqApprovalThresholdRaw);
+if (!Number.isFinite(nlqApprovalThreshold)) {
+  nlqApprovalThreshold = 0.8;
+}
+nlqApprovalThreshold = Math.min(Math.max(nlqApprovalThreshold, 0), 1);
+
 export default Object.freeze({
   port: Number.parseInt(config.PORT, 10) || 3000,
   nodeEnv: config.NODE_ENV,
@@ -70,5 +77,8 @@ export default Object.freeze({
     model: config.GEMINI_MODEL
   },
   defaultCompanyId: config.DEFAULT_COMPANY_ID,
-  logLevel: config.LOG_LEVEL
+  logLevel: config.LOG_LEVEL,
+  nlq: {
+    approvalThreshold: nlqApprovalThreshold
+  }
 });

--- a/api/src/nlq/questions.js
+++ b/api/src/nlq/questions.js
@@ -1,0 +1,141 @@
+import { runCypher } from '../db/neo4j.js';
+
+const DEFAULT_APPROVAL_THRESHOLD = 0.8;
+const GLOBAL_COMPANY_KEY = '__global__';
+
+function normalizeCompanyKey(companyId) {
+  return companyId && companyId.length > 0 ? companyId : GLOBAL_COMPANY_KEY;
+}
+
+function mapNode(node) {
+  if (!node) {
+    return null;
+  }
+
+  const { properties } = node;
+
+  return {
+    text: properties.text,
+    normalizedText: properties.normalizedText,
+    cypher: properties.cypher,
+    approval: typeof properties.approval?.toNumber === 'function'
+      ? properties.approval.toNumber()
+      : properties.approval,
+    companyId: properties.companyKey === GLOBAL_COMPANY_KEY ? null : properties.companyKey,
+    companyKey: properties.companyKey
+  };
+}
+
+export async function findApprovedQuestion({
+  normalizedText,
+  companyId,
+  threshold = DEFAULT_APPROVAL_THRESHOLD
+}) {
+  const companyKey = normalizeCompanyKey(companyId);
+  const params = {
+    normalizedText,
+    companyKey,
+    threshold,
+    globalKey: GLOBAL_COMPANY_KEY
+  };
+
+  const query = `
+MATCH (q:NlqQuestion { normalizedText: $normalizedText, companyKey: $companyKey })
+WHERE coalesce(q.approval, 0) >= $threshold
+RETURN q
+ORDER BY q.updatedAt DESC
+LIMIT 1
+`;
+
+  const result = await runCypher(query, params);
+  if (result.records.length) {
+    return mapNode(result.records[0].get('q'));
+  }
+
+  if (companyKey === GLOBAL_COMPANY_KEY) {
+    return null;
+  }
+
+  const fallback = await runCypher(
+    `
+MATCH (q:NlqQuestion { normalizedText: $normalizedText, companyKey: $globalKey })
+WHERE coalesce(q.approval, 0) >= $threshold
+RETURN q
+ORDER BY q.updatedAt DESC
+LIMIT 1
+    `,
+    params
+  );
+
+  if (!fallback.records.length) {
+    return null;
+  }
+
+  return mapNode(fallback.records[0].get('q'));
+}
+
+export async function registerQuestionUsage({ normalizedText, companyId }) {
+  const companyKey = normalizeCompanyKey(companyId);
+  const now = new Date().toISOString();
+
+  await runCypher(
+    `
+MATCH (q:NlqQuestion { normalizedText: $normalizedText, companyKey: $companyKey })
+SET q.lastUsedAt = datetime($now),
+    q.updatedAt = datetime($now),
+    q.usageCount = coalesce(q.usageCount, 0) + 1
+RETURN q
+    `,
+    {
+      normalizedText,
+      companyKey,
+      now
+    }
+  );
+}
+
+export async function registerQuestionSuccess({
+  text,
+  normalizedText,
+  companyId,
+  cypher,
+  approval = 1
+}) {
+  const companyKey = normalizeCompanyKey(companyId);
+  const now = new Date().toISOString();
+
+  await runCypher(
+    `
+MERGE (q:NlqQuestion { normalizedText: $normalizedText, companyKey: $companyKey })
+ON CREATE SET
+  q.text = $text,
+  q.cypher = $cypher,
+  q.approval = $approval,
+  q.companyId = $companyId,
+  q.createdAt = datetime($now),
+  q.updatedAt = datetime($now),
+  q.lastUsedAt = datetime($now),
+  q.usageCount = 1
+ON MATCH SET
+  q.text = $text,
+  q.cypher = $cypher,
+  q.approval = CASE WHEN $approval > coalesce(q.approval, 0) THEN $approval ELSE q.approval END,
+  q.companyId = $companyId,
+  q.updatedAt = datetime($now),
+  q.lastUsedAt = datetime($now),
+  q.usageCount = coalesce(q.usageCount, 0) + 1
+RETURN q
+    `,
+    {
+      text,
+      normalizedText,
+      companyKey,
+      companyId,
+      cypher,
+      approval,
+      now
+    }
+  );
+}
+
+export { DEFAULT_APPROVAL_THRESHOLD };

--- a/cypher/01_schema.cypher
+++ b/cypher/01_schema.cypher
@@ -22,6 +22,10 @@ CREATE CONSTRAINT alert_id_unique IF NOT EXISTS
 FOR (a:Alert)
 REQUIRE a.id IS UNIQUE;
 
+CREATE CONSTRAINT nlq_question_identity_unique IF NOT EXISTS
+FOR (q:NlqQuestion)
+REQUIRE (q.companyKey, q.normalizedText) IS UNIQUE;
+
 MERGE (c:Company {id: 'company-1'})
 ON CREATE SET c.name = 'Empresa Demo'
 RETURN c;


### PR DESCRIPTION
## Summary
- create a Neo4j-backed catalog for NLQ questions and reuse approved Cypher without calling Gemini
- persist successful NLQ executions with automatic 100% approval and usage metrics while exposing the source in the response
- allow configuring the approval threshold via NLQ_APPROVAL_THRESHOLD and document the updated NLQ flow, including the new catalog constraint

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dc016c46f4832d9d3ce40acda45d5e