### PR TITLE
fix: update timescaledb image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - default
 
   timescale:
-    image: timescale/timescaledb-ha:pg16-latest
+    image: timescale/timescaledb-ha:pg16.4
     environment:
       POSTGRES_DB: energy
       POSTGRES_USER: postgres

--- a/setup.sh
+++ b/setup.sh
@@ -79,7 +79,7 @@ services:
       - default
 
   timescale:
-    image: timescale/timescaledb-ha:pg16-latest
+    image: timescale/timescaledb-ha:pg16.4
     environment:
       POSTGRES_DB: energy
       POSTGRES_USER: postgres


### PR DESCRIPTION
## Summary
- replace the deprecated `pg16-latest` TimescaleDB HA image tag with `pg16.4`
- align the setup script with the new image tag so bootstrap flows use the same version

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc0b92e80c832d82b84a2eaf5949b8