### PR TITLE
Add HTTP telemetry ingestion route and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Os serviços provisionados incluem:
 1. Garanta que Docker e Docker Compose v2 estejam instalados.
 2. Execute o script `./setup.sh` na raiz do repositório.
 3. Aguarde a criação dos arquivos, subida dos containers e aplicação dos schemas.
-4. Opcionalmente, publique uma mensagem de exemplo com `./scripts/demo_publish.sh`.
+4. Opcionalmente, publique uma mensagem de exemplo com `./scripts/demo_publish.sh` ou utilize o script `./scripts/month_fill.ps1` para enviar um mês de amostras sintéticas via HTTP.
 
 O arquivo `.env` é gerado com valores padrão seguros para desenvolvimento. Ajuste conforme necessário antes de rodar em produção.
 
@@ -39,4 +39,10 @@ O arquivo `.env` é gerado com valores padrão seguros para desenvolvimento. Aju
 A API expõe autenticação via JWT. Para obter um token, faça uma requisição `POST /auth/login` com `username` e `password` definidos nas variáveis de ambiente `AUTH_USERNAME` e `AUTH_PASSWORD`. Opcionalmente informe `companyId` para vincular o token a uma empresa específica; caso contrário, será usada `DEFAULT_COMPANY_ID`.
 
 Utilize o token recebido no cabeçalho `Authorization: Bearer <token>` para acessar rotas protegidas, como `POST /nlq/query`.
+
+## Ingestão HTTP de telemetria
+
+Além da ingestão via MQTT, a API expõe o endpoint autenticado `POST /companies/{companyId}/boards/{boardId}/telemetry`. Ele aceita um objeto único ou um array de objetos com os campos `logical_id`, `ts` e métricas opcionais (`voltage`, `current`, `frequency`, `power_factor`).
+
+O script `scripts/month_fill.ps1` demonstra como autenticar, gerar e enviar amostras sequenciais para este endpoint usando PowerShell.
      main

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -5,6 +5,7 @@ import config from './config.js';
 import registerHealthRoute from './routes/health.js';
 import registerNlqRoute from './routes/nlq.js';
 import registerAuthRoute from './routes/auth.js';
+import registerTelemetryRoute from './routes/telemetry.js';
 import { verifyConnectivity as verifyTimescale, closePool } from './db/timescale.js';
 import { verifyConnectivity as verifyNeo4j, closeDriver } from './db/neo4j.js';
 import { startMqttIngest } from './ingest/mqtt.js';
@@ -39,6 +40,7 @@ app.decorate('authenticate', async function authenticate(request, reply) {
 app.register(registerHealthRoute);
 app.register(registerAuthRoute);
 app.register(registerNlqRoute);
+app.register(registerTelemetryRoute);
 
 let stopMqtt = null;
 

--- a/api/src/routes/telemetry.js
+++ b/api/src/routes/telemetry.js
@@ -1,0 +1,117 @@
+import { insertTelemetry } from '../db/timescale.js';
+
+function normalizeSamples(body) {
+  if (Array.isArray(body)) {
+    return body;
+  }
+
+  if (body && typeof body === 'object') {
+    return [body];
+  }
+
+  return [];
+}
+
+export default async function registerTelemetryRoutes(fastify) {
+  fastify.post('/companies/:companyId/boards/:boardId/telemetry', {
+    preValidation: [fastify.authenticate],
+    schema: {
+      params: {
+        type: 'object',
+        required: ['companyId', 'boardId'],
+        properties: {
+          companyId: { type: 'string', minLength: 1 },
+          boardId: { type: 'string', minLength: 1 }
+        }
+      },
+      body: {
+        oneOf: [
+          {
+            type: 'object',
+            required: ['logical_id', 'ts'],
+            properties: {
+              logical_id: { type: 'string', minLength: 1 },
+              ts: { type: 'string', minLength: 1 },
+              voltage: { type: 'number' },
+              current: { type: 'number' },
+              frequency: { type: 'number' },
+              power_factor: { type: 'number' }
+            }
+          },
+          {
+            type: 'array',
+            minItems: 1,
+            items: {
+              type: 'object',
+              required: ['logical_id', 'ts'],
+              properties: {
+                logical_id: { type: 'string', minLength: 1 },
+                ts: { type: 'string', minLength: 1 },
+                voltage: { type: 'number' },
+                current: { type: 'number' },
+                frequency: { type: 'number' },
+                power_factor: { type: 'number' }
+              }
+            }
+          }
+        ]
+      },
+      response: {
+        202: {
+          type: 'object',
+          required: ['accepted'],
+          properties: {
+            accepted: { type: 'integer', minimum: 1 }
+          }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    const { companyId, boardId } = request.params;
+    const samples = normalizeSamples(request.body);
+
+    if (samples.length === 0) {
+      reply.code(400);
+      return {
+        code: 'INVALID_PAYLOAD',
+        message: 'O corpo da requisição deve ser um objeto ou array com amostras válidas.'
+      };
+    }
+
+    let accepted = 0;
+
+    for (const sample of samples) {
+      if (!sample.logical_id || !sample.ts) {
+        fastify.log.warn({ sample }, 'Amostra ignorada por falta de logical_id ou ts');
+        continue;
+      }
+
+      try {
+        await insertTelemetry({
+          companyId,
+          logicalId: sample.logical_id,
+          ts: sample.ts,
+          voltage: sample.voltage ?? null,
+          current: sample.current ?? null,
+          frequency: sample.frequency ?? null,
+          powerFactor: sample.power_factor ?? null,
+          payload: { ...sample, board_id: boardId }
+        });
+        accepted += 1;
+      } catch (err) {
+        fastify.log.error({ err, sample }, 'Falha ao inserir amostra de telemetria');
+      }
+    }
+
+    if (accepted === 0) {
+      reply.code(400);
+      return {
+        code: 'NO_SAMPLES_ACCEPTED',
+        message: 'Nenhuma amostra válida foi processada.'
+      };
+    }
+
+    reply.code(202);
+    return { accepted };
+  });
+}

--- a/scripts/month_fill.ps1
+++ b/scripts/month_fill.ps1
@@ -1,0 +1,83 @@
+param(
+    [string]$BaseUrl = "http://localhost:3000",
+    [string]$Username = "admin",
+    [string]$Password = "admin",
+    [string]$CompanyId = "company-1",
+    [string]$BoardId = "board-1",
+    [string]$DeviceId = "device-123",
+    [datetime]$Start = (Get-Date).ToUniversalTime().AddMonths(-1).Date,
+    [int]$Days = 30,
+    [int]$IntervalMinutes = 60,
+    [int]$SleepMs = 0
+)
+
+if ($IntervalMinutes -le 0) {
+    throw "IntervalMinutes deve ser maior que zero."
+}
+if ($Days -le 0) {
+    throw "Days deve ser maior que zero."
+}
+
+try {
+    $baseUri = [Uri]::new($BaseUrl)
+} catch {
+    throw "BaseUrl inválida: $_"
+}
+
+$end = $Start.AddDays($Days)
+$telemetryUrl = "{0}/companies/{1}/boards/{2}/telemetry" -f $baseUri.AbsoluteUri.TrimEnd('/'), $CompanyId, $BoardId
+$loginUrl = "{0}/auth/login" -f $baseUri.AbsoluteUri.TrimEnd('/')
+
+Write-Host "[info] Publicando medições de $($Start.ToString('u')) até $($end.ToString('u')) via $telemetryUrl" -ForegroundColor Cyan
+
+$loginBody = @{
+    username = $Username
+    password = $Password
+    companyId = $CompanyId
+} | ConvertTo-Json
+
+try {
+    $loginResponse = Invoke-RestMethod -Method Post -Uri $loginUrl -Body $loginBody -ContentType "application/json" -ErrorAction Stop
+} catch {
+    throw "Falha ao autenticar na API: $_"
+}
+
+if (-not $loginResponse.token) {
+    throw "Resposta de autenticação inválida: token ausente."
+}
+
+$headers = @{
+    Authorization = "Bearer $($loginResponse.token)"
+    'Content-Type' = 'application/json'
+}
+
+for ($ts = $Start; $ts -lt $end; $ts = $ts.AddMinutes($IntervalMinutes)) {
+    $payloadObj = [ordered]@{
+        logical_id  = $DeviceId
+        ts          = $ts.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        voltage     = [Math]::Round(220 + (Get-Random -Minimum -5.0 -Maximum 5.0), 2)
+        current     = [Math]::Round(5 + (Get-Random -Minimum -1.5 -Maximum 1.5), 2)
+        frequency   = [Math]::Round(60 + (Get-Random -Minimum -0.4 -Maximum 0.4), 2)
+        power_factor = [Math]::Round(0.92 + (Get-Random -Minimum -0.05 -Maximum 0.05), 2)
+    }
+
+    $payload = $payloadObj | ConvertTo-Json -Compress
+
+    Write-Host ("[POST] {0}" -f $payload) -ForegroundColor Green
+
+    try {
+        $response = Invoke-RestMethod -Method Post -Uri $telemetryUrl -Headers $headers -Body $payload -ContentType "application/json" -ErrorAction Stop
+    } catch {
+        throw "Falha ao enviar amostra para $telemetryUrl: $_"
+    }
+
+    if ($response.accepted -lt 1) {
+        throw "Nenhuma amostra aceita na resposta da API."
+    }
+
+    if ($SleepMs -gt 0) {
+        Start-Sleep -Milliseconds $SleepMs
+    }
+}
+
+Write-Host "[ok] Publicação concluída" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- add an authenticated HTTP endpoint to ingest telemetry samples per company and board
- update the month_fill PowerShell helper to authenticate and post telemetry via the new endpoint
- document the HTTP ingestion option in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd0a08f8b4832dbabc656cdd810970